### PR TITLE
Created a field type for the color picker and an HTML element

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/*
 .eslintrc.js
 package-lock.json
 package.json
+/.vscode

--- a/README.md
+++ b/README.md
@@ -11,6 +11,23 @@ This module uses a modified version of the [jscolor](https://github.com/EastDesi
 For info about **jscolor** Color Picker, see the [jscolor website](https://jscolor.com).
 
 # How to Use
+## Registering a Setting
+To create a setting that works as a color picker, you just need to set the type on the setting to be `new game.colorPicker!.ColorPickerField()`. Example:
+```
+game.settings.register("your-module", "your-setting-key", {
+    name: "Your Cool Color",
+    hint: "This color is used for cool stuff",
+    scope: "client",
+    config: true,
+    type: new game.colorPicker.ColorPickerField(),
+});
+```
+You can optionally provide the [format](#format) you wish to use like so (the default is "hexa"):
+```type: new game.colorPicker.ColorPickerField({ format: "hex" })```
+
+# The Old Way
+> [!CAUTION]
+> It's highly recommended to use the ColorPickerField directly as described above. The old method remains functional for the time being but mostly as a way to keep existing modules working. This may be deprecated in the future.
 ## Register a Module Setting
 As with FoundryVTT's [ClientSettings.register](https://foundryvtt.com/api/ClientSettings.html#register) function, use the `ColorPicker.register(module, key, {settingOptions}, {pickerOptions})` function to register a new color picker setting for a module. `module` is the ID of the module, `key` is the name of the setting, `{settingOptions}` is a comma-separated list of options related to the `ClientSettings.register` function (see Setting Options) and `{pickerOptions}` is a comma-separated list of options for the picker (see Picker Options).
 
@@ -144,6 +161,7 @@ Whether to overwrite the CSS style of the previewElement using the !important fl
 
 Example: `forceStyle: false`
 
+<a name="format"></a>
 ### **format**
 The format of the displayed color value.
 - **'auto':** Base the format on the initial color value.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ game.settings.register("your-module", "your-setting-key", {
 });
 ```
 You can optionally provide the [format](#format) you wish to use like so (the default is "hexa"):
+
 ```type: new game.colorPicker.ColorPickerField({ format: "hex" })```
 
 ## In a Handlebars Template

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ For info about **jscolor** Color Picker, see the [jscolor website](https://jscol
 
 # How to Use
 ## Registering a Setting
-To create a setting that works as a color picker, you just need to set the type on the setting to be `new game.colorPicker!.ColorPickerField()`. Example:
+To create a setting that works as a color picker, you just need to set the type on the setting to be `new game.colorPicker.ColorPickerField()`.
+
+Example:
 ```
 game.settings.register("your-module", "your-setting-key", {
     name: "Your Cool Color",
@@ -25,9 +27,14 @@ game.settings.register("your-module", "your-setting-key", {
 You can optionally provide the [format](#format) you wish to use like so (the default is "hexa"):
 ```type: new game.colorPicker.ColorPickerField({ format: "hex" })```
 
+## In a Handlebars Template
+To use the color picker in any hbs template file (the most common use case being a settings menu), provide the type through the data context with `new game.colorPicker.ColorPickerField()` as above. Then just use either the formInput or formGroup helper. You can learn more about those helpers on the [community wiki](https://foundryvtt.wiki/en/development/api/helpers).
+
+
 # The Old Way
 > [!CAUTION]
-> It's highly recommended to use the ColorPickerField directly as described above. The old method remains functional for the time being but mostly as a way to keep existing modules working. This may be deprecated in the future.
+> It's highly recommended to use the ColorPickerField directly as described above. The old method remains functional for the time being but mostly as a way to keep existing modules working. THis is also currently the only way to do extra customization on the appearance of the picker itself. This may be deprecated in the future.
+
 ## Register a Module Setting
 As with FoundryVTT's [ClientSettings.register](https://foundryvtt.com/api/ClientSettings.html#register) function, use the `ColorPicker.register(module, key, {settingOptions}, {pickerOptions})` function to register a new color picker setting for a module. `module` is the ID of the module, `key` is the name of the setting, `{settingOptions}` is a comma-separated list of options related to the `ClientSettings.register` function (see Setting Options) and `{pickerOptions}` is a comma-separated list of options for the picker (see Picker Options).
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To use the color picker in any hbs template file (the most common use case being
 
 # The Old Way
 > [!CAUTION]
-> It's highly recommended to use the ColorPickerField directly as described above. The old method remains functional for the time being but mostly as a way to keep existing modules working. THis is also currently the only way to do extra customization on the appearance of the picker itself. This may be deprecated in the future.
+> It's recommended to use the ColorPickerField directly as described above. The old method remains functional for the time being but mostly as a way to keep existing modules working. THis is also currently the only way to do extra customization on the appearance of the picker itself. This may be deprecated in the future.
 
 ## Register a Module Setting
 As with FoundryVTT's [ClientSettings.register](https://foundryvtt.com/api/ClientSettings.html#register) function, use the `ColorPicker.register(module, key, {settingOptions}, {pickerOptions})` function to register a new color picker setting for a module. `module` is the ID of the module, `key` is the name of the setting, `{settingOptions}` is a comma-separated list of options related to the `ClientSettings.register` function (see Setting Options) and `{pickerOptions}` is a comma-separated list of options for the picker (see Picker Options).

--- a/README.md
+++ b/README.md
@@ -161,7 +161,6 @@ Whether to overwrite the CSS style of the previewElement using the !important fl
 
 Example: `forceStyle: false`
 
-<a name="format"></a>
 ### **format**
 The format of the displayed color value.
 - **'auto':** Base the format on the initial color value.

--- a/scripts/alpha-color-picker-element.js
+++ b/scripts/alpha-color-picker-element.js
@@ -1,0 +1,103 @@
+import JsColor from './lib/jscolor.js'
+
+/**
+ * @typedef AbstractFormInputElement
+ * @property {string} value  A hexadecimal string representation of the color.
+ */
+
+/**
+ * A custom HTMLElement used to select a color and alpha
+ * @extends {AbstractFormInputElement<string>}
+ */
+export class HTMLAlphaColorPickerElement extends foundry.applications.elements.AbstractFormInputElement {
+  /**
+   * @param {HTMLColorPickerOptions} [options]
+   */
+  constructor({ value }={}) {
+    super();
+    this._setValue(value || this.getAttribute("value")); // Initialize existing color value
+  }
+
+  /** @override */
+  static tagName = "alpha-color-picker";
+
+  /* -------------------------------------------- */
+
+  /**
+   * The input element to define a Document UUID.
+   * @type {HTMLInputElement}
+   */
+  #colorString;
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _buildElements() {
+    // Create string input element
+    this.#colorString = this._primaryInput = document.createElement("input");
+    this.#colorString.type = "text";
+    this.#colorString.placeholder = this.getAttribute("placeholder") || "";
+    this._applyInputAttributes(this.#colorString);
+    return [this.#colorString];
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _refresh() {
+    if ( !this.#colorString ) return; // Not yet connected
+    this.#colorString.value = this._value;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _activateListeners() {
+    this.pickerOptions = {
+      alpha: true,
+      format: "hexa",
+      value: this._value
+    }
+
+    //This both modifies the element and added event handlers
+    new JsColor(this.#colorString, this.pickerOptions);
+
+    //JsColor will update the HTML input but we still need to handle the change so we can update our value
+    const onChange = this.#onChangeInput.bind(this);
+    this.#colorString.addEventListener("change", onChange);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle changes to one of the inputs of the color picker element.
+   * @param {InputEvent} event     The originating input change event
+   */
+  #onChangeInput(event) {
+    event.stopPropagation();
+    this.value = event.currentTarget.value;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _toggleDisabled(disabled) {
+    this.#colorString.disabled = disabled;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Create a HTMLAlphaColorPickerElement using provided configuration data.
+   * @param {FormInputConfig} config
+   * @returns {HTMLAlphaColorPickerElement}
+   */
+  static create(config) {
+    const { value } = config;
+    const picker = new this({ value });
+    picker.name = config.name;
+    picker.setAttribute("value", config.value ?? "");
+    foundry.applications.fields.setInputAttributes(picker, config);
+    return picker;
+  }
+}

--- a/scripts/alpha-color-picker-element.js
+++ b/scripts/alpha-color-picker-element.js
@@ -59,7 +59,7 @@ export class HTMLAlphaColorPickerElement extends foundry.applications.elements.A
       value: this._value
     }
 
-    //This both modifies the element and added event handlers
+    //This both modifies the element and adds event handlers
     new JsColor(this.#colorString, this.pickerOptions);
 
     //JsColor will update the HTML input but we still need to handle the change so we can update our value

--- a/scripts/alpha-color-picker-element.js
+++ b/scripts/alpha-color-picker-element.js
@@ -13,9 +13,10 @@ export class HTMLAlphaColorPickerElement extends foundry.applications.elements.A
   /**
    * @param {HTMLColorPickerOptions} [options]
    */
-  constructor({ value }={}) {
+  constructor({ value, format }={}) {
     super();
     this._setValue(value || this.getAttribute("value")); // Initialize existing color value
+    this._format = format || this.getAttribute("format");
   }
 
   /** @override */
@@ -54,8 +55,7 @@ export class HTMLAlphaColorPickerElement extends foundry.applications.elements.A
   /** @override */
   _activateListeners() {
     this.pickerOptions = {
-      alpha: true,
-      format: "hexa",
+      format: this._format ?? "hexa",
       value: this._value
     }
 
@@ -93,10 +93,10 @@ export class HTMLAlphaColorPickerElement extends foundry.applications.elements.A
    * @returns {HTMLAlphaColorPickerElement}
    */
   static create(config) {
-    const { value } = config;
-    const picker = new this({ value });
+    const picker = new this(config);
     picker.name = config.name;
     picker.setAttribute("value", config.value ?? "");
+    picker.setAttribute("format", config.format ?? "");
     foundry.applications.fields.setInputAttributes(picker, config);
     return picker;
   }

--- a/scripts/color-picker-field.js
+++ b/scripts/color-picker-field.js
@@ -1,0 +1,49 @@
+import { HTMLAlphaColorPickerElement } from './alpha-color-picker-element.js';
+
+/**
+ * A field for picking a color and alpha
+ * @extends {foundry.data.fields.StringField}
+ */
+export class ColorPickerField extends foundry.data.fields.StringField {
+
+  /** @inheritdoc */
+  static get _defaults() {
+    return foundry.utils.mergeObject(super._defaults, {
+      nullable: true,
+      initial: null,
+      blank: false,
+      validationError: "is not a valid hexadecimal color string"
+    });
+  }
+
+  /** @inheritdoc */
+  _validateType(value, options) {
+    if (!this.isAlphaColorString(value)) throw new Error("must be a valid color string");
+    return super._validateType(value, options);
+  }
+
+  isAlphaColorString(color) {
+    return /^#[0-9A-Fa-f]{8}$/.test(color);
+  }
+
+  createPickerInput(config) {
+    const input = document.createElement("input");
+    input.type = "text";
+    input.name = config.name;
+    input.setAttribute("value", config.value ?? "");
+    foundry.applications.fields.setInputAttributes(input, config);
+    return input;
+  }
+
+  /* -------------------------------------------- */
+  /*  Form Field Integration                      */
+  /* -------------------------------------------- */
+
+  /** @override */
+  _toInput(config) {
+    if ((config.placeholder === undefined) && !this.nullable && !(this.initial instanceof Function)) {
+      config.placeholder = this.initial;
+    }
+    return HTMLAlphaColorPickerElement.create(config);
+  }
+}

--- a/scripts/color-picker.js
+++ b/scripts/color-picker.js
@@ -1,10 +1,15 @@
 import JsColor from './lib/jscolor.js'
+import { ColorPickerField } from './color-picker-field.js';
+import { HTMLAlphaColorPickerElement } from './alpha-color-picker-element.js';
 
 Hooks.once('init', function () {
   window.ColorPicker = {
     register,
     install: JsColor.install
   }
+  window.customElements.define(HTMLAlphaColorPickerElement.tagName, HTMLAlphaColorPickerElement);
+  game.colorPicker = {};
+  game.colorPicker.ColorPickerField = ColorPickerField;
   Hooks.callAll('colorPickerReady', window.ColorPicker)
 })
 


### PR DESCRIPTION
This change makes the ColorPicker an actual field. What this means is that it can be used in places that take a DataField (e.g. the type on a setting) as well as the ability to use it as in input in hbs files via the `{{formInput` and `{{formGroup` handlebars helpers.

The big draw of this, and the reason I implemented it, is it allows the ColorPicker to be used without all the extra boilerplate. You can now register settings with the type set to `type: new game.colorPicker.ColorPickerField(),` and it will automatically do the rest. This also allows it to be used inside of settings menus by passing the type to the data context and using the appropriate handlebars helper.

I haven't tested this in v13 yet.

Let me know if you have any questions.